### PR TITLE
call C/Neon/Aseembly and compare results

### DIFF
--- a/armAssembly/CMakeLists.txt
+++ b/armAssembly/CMakeLists.txt
@@ -13,6 +13,9 @@ project(getCPUid)
 
 set(CMAKE_CXX_STANDARD 11)
 
+# generate compile_commands.json for function jumps
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 #include_directories(${PROJECT_SOURCE_DIR}/src)
 
 # Only usefull in gcc


### PR DESCRIPTION
Hi Depeng

我给 armAssembly 目录下的两个 .cpp 文件做了修改：分别调用 C / Neon / Assembly 的实现，并对比结果。

在 Android Arm 64 下运行，NDK版本r21b

assemblyEx1ArrWeightSum.cpp 的三个实现，结果相同
assemblyEx2Rgb2Gray.cpp 的三个实现，neon intrinsics 和 assembly 结果相同，但和普通C实现有所差别。

测试图片：
![000017](https://user-images.githubusercontent.com/3831847/102562814-d729f500-4112-11eb-8de0-215c16cd8c0b.jpg)

差异可视化：
![image](https://user-images.githubusercontent.com/3831847/102562843-e7da6b00-4112-11eb-9b22-5704103a7af7.png)
